### PR TITLE
Make zone section last in the knot.conf template

### DIFF
--- a/templates/knot.conf.j2
+++ b/templates/knot.conf.j2
@@ -24,6 +24,9 @@ key:
 {% endif %}
 {% endfor %}
 
+# Server-specific extras
+{{ knot_extras }}
+
 # Zone lists
 zone:
 {% for zone in knot_zones %}
@@ -38,7 +41,4 @@ zone:
     file: {{ zone.file }}
 {% endif %}
 {% endfor %}
-
-# Server-specific extras
-{{ knot_extras }}
 


### PR DESCRIPTION
I was not able to use zone templates, because templates are defined in knot_extras variable.

knotc conf-check results in invalid references in knot configuration file. So everything referenced from zones should be above them.